### PR TITLE
feat: module for Polyglot Context injection

### DIFF
--- a/graal-languages-core/build.gradle.kts
+++ b/graal-languages-core/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("io.micronaut.build.internal.graal-languages-module")
+}
+dependencies {
+    api(libs.managed.graal.polyglot)
+    implementation(mn.micronaut.context)
+    testRuntimeOnly(libs.managed.graal.js)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.jackson.databind)
+    testImplementation(mn.micronaut.http.client)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+}
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+micronautBuild {
+    binaryCompatibility {
+        enabled.set(false)
+    }
+}

--- a/graal-languages-core/src/main/java/io/micronaut/graallanguages/ContextFactory.java
+++ b/graal-languages-core/src/main/java/io/micronaut/graallanguages/ContextFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.graallanguages;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.runtime.context.scope.ThreadLocal;
+import jakarta.inject.Singleton;
+import org.graalvm.polyglot.Context;
+
+@Internal
+@Factory
+class ContextFactory {
+    @Singleton
+    Context.Builder createContextBuilder() {
+        return Context.newBuilder();
+    }
+
+    @ThreadLocal
+    ContextProvider createContext(Context.Builder builder) {
+        ContextProvider contextProvider = new ContextProvider();
+        contextProvider.setContext(builder.build());
+        return contextProvider;
+    }
+}

--- a/graal-languages-core/src/main/java/io/micronaut/graallanguages/ContextProvider.java
+++ b/graal-languages-core/src/main/java/io/micronaut/graallanguages/ContextProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.graallanguages;
+
+import io.micronaut.core.annotation.Experimental;
+import org.graalvm.polyglot.Context;
+
+/**
+ * Wrapper around {@link Context} since it is a final class and cannot be proxied after its instantiation in a factory.
+ * @author Sergio del Amo
+ * @since 1.1.0
+ */
+@Experimental
+public class ContextProvider {
+    private Context context;
+
+    /**
+     * Empty Constructor.
+     */
+    public ContextProvider() {
+    }
+
+    /**
+     *
+     * @param context Graal Languages {@link Context}
+     */
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    /**
+     *
+     * @return Graal Languages {@link Context}
+     */
+    public Context getContext() {
+        return context;
+    }
+}

--- a/graal-languages-core/src/test/java/io/micronaut/graallanguages/core/HomeController.java
+++ b/graal-languages-core/src/test/java/io/micronaut/graallanguages/core/HomeController.java
@@ -1,0 +1,33 @@
+package io.micronaut.graallanguages.core;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.graallanguages.ContextProvider;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import org.graalvm.polyglot.Value;
+
+@Requires(property = "spec.name", value = "HomeControllerTest")
+//tag::controller[]
+@Controller
+public class HomeController {
+    private final ContextProvider contextProvider;
+
+    HomeController(ContextProvider contextProvider) {
+        this.contextProvider = contextProvider;
+    }
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @Get
+    HttpResponse<String> index() {
+        Value f = contextProvider.getContext().eval("js", "x => x + 1");
+        if (f.canExecute()) {
+            return HttpResponse.ok("" + f.execute(41).asInt());
+        }
+        return HttpResponse.serverError();
+    }
+}
+//end::controller[]

--- a/graal-languages-core/src/test/java/io/micronaut/graallanguages/core/HomeControllerTest.java
+++ b/graal-languages-core/src/test/java/io/micronaut/graallanguages/core/HomeControllerTest.java
@@ -1,0 +1,24 @@
+package io.micronaut.graallanguages.core;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "spec.name", value = "HomeControllerTest")
+@MicronautTest
+class HomeControllerTest {
+
+    @Test
+    void jsembedding(@Client("/") HttpClient httpClient) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpRequest<?> request = HttpRequest.GET("/").accept(MediaType.TEXT_PLAIN_TYPE);
+        assertEquals("42", client.retrieve(request));
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ micronaut-test = { module = "io.micronaut.test:micronaut-test-bom", version.ref 
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 
+managed-graal-js = { module = 'org.graalvm.js:js', version.ref = 'managed-graalpy' }
+managed-graal-polyglot = { module = 'org.graalvm.polyglot:polyglot', version.ref = 'managed-graalpy' }
 managed-graalpy = { module = 'org.graalvm.python:python', version.ref = 'managed-graalpy' }
 managed-graalpy-embedding = { module = 'org.graalvm.python:python-embedding', version.ref = 'managed-graalpy' }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,7 @@ rootProject.name = 'micronaut-graal-languages'
 
 include 'graalpy'
 include 'graal-languages-bom'
+include 'graal-languages-core'
 include 'test-suite-graalpy'
 
 enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'

--- a/src/main/docs/guide/embedding.adoc
+++ b/src/main/docs/guide/embedding.adoc
@@ -1,0 +1,11 @@
+You can embed https://www.graalvm.org/latest/reference-manual/languages/[Graal Languages] in your application. For example, to embed Javascript you could add the following dependencies:
+
+dependency:io.micronaut.micronaut-graal-languages:micronaut-graal-languages-core[scope=compile]
+
+dependency:org.graalvm.js:js[scope=runtime]
+
+[source,java]
+.src/main/java/example/micronaut/HomeController.java
+----
+include::{sourceDir}/graal-languages-core/src/test/java/io/micronaut/graallanguages/core/HomeController.java[tag=controller, indent=0]
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -1,5 +1,6 @@
 introduction: Introduction
 releaseHistory: Release History
+embedding: Embedding Graal Languages
 graalPy:
   title: GraalPy
   gettingStarted: Getting Started


### PR DESCRIPTION
@steve-s and I put together this proof of concept for allowing users to inject Graal Languages Context into their application. I think using @ThreadLocal could good for this use case. 

@steve-s will update you with details about the Context constraints. 

Thoughts @fniephaus @mikehearn @dstepanov @graemerocher ?