### PR TITLE
Upgrade graalpy to 24.2.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ micronaut = "4.8.8"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.7.0"
 groovy = "4.0.22"
-managed-graalpy = "24.1.2"
+managed-graalpy = "24.2.0"
 sonatype-scan = "3.0.0"
 
 [libraries]

--- a/src/main/docs/guide/graalPy/gettingStarted.adoc
+++ b/src/main/docs/guide/graalPy/gettingStarted.adoc
@@ -4,10 +4,11 @@ To use the GraalPy integration:
 
 dependency:io.micronaut.micronaut-graal-languages:micronaut-graalpy[scope=compile]
 
-2) Add the https://github.com/oracle/graalpython/blob/master/docs/user/Embedding-Build-Tools.md[GraalPy Maven plugin]
+2) Add the GraalPy plugin configuration for your build tool
 
-WARNING: Gradle plugin not available yet
+2a) https://github.com/oracle/graalpython/blob/master/docs/user/Embedding-Build-Tools.md#graalPy-maven-plugin[GraalPy Maven plugin]
 
+_pom.xml_
 [source,xml]
 ----
 <build>
@@ -20,7 +21,7 @@ WARNING: Gradle plugin not available yet
       <execution>
         <configuration>
           <packages>
-            <package>termcolor==2.2</package> // (1)
+            <package>termcolor==2.2</package> <!-- (1) -->
           </packages>
         </configuration>
       </execution>
@@ -28,6 +29,21 @@ WARNING: Gradle plugin not available yet
   </plugin>
  </plugins>
  <!-- ... -->
+----
+
+2b) https://github.com/oracle/graalpython/blob/master/docs/user/Embedding-Build-Tools.md#graalPy-gradle-plugin[GraalPy Gradle plugin]
+
+_build.gradle_
+[source,groovy]
+----
+plugins {
+    ...
+    id("org.graalvm.python") version "24.2.0"
+}
+
+graalPy {
+    packages = ["termcolor==2.2"] // (1)
+}
 ----
 
 <1> Optional list of Python Package Index (PyPI) packages to be automatically

--- a/test-suite-graalpy/src/test/resources/org.graalvm.python.vfs/fileslist.txt
+++ b/test-suite-graalpy/src/test/resources/org.graalvm.python.vfs/fileslist.txt
@@ -1,0 +1,1 @@
+/org.graalvm.python.vfs/readme

--- a/test-suite-graalpy/src/test/resources/org.graalvm.python.vfs/readme
+++ b/test-suite-graalpy/src/test/resources/org.graalvm.python.vfs/readme
@@ -1,0 +1,1 @@
+the contents of resources/org.graalvm.python.vfs directory are test resources for graalpy virtual filesystem


### PR DESCRIPTION
- raised graalpy version
- added empty test/resources/org.graalvm.python.vfs/fileslist.txt which is since 24.2.0 accessed already on graalpy init