### PR TITLE
Fix CVE vulnerability

### DIFF
--- a/graalpy/build.gradle
+++ b/graalpy/build.gradle
@@ -10,5 +10,12 @@ dependencies {
         transitive = true
     }
     api(libs.managed.graalpy.embedding)
+
+    constraints {
+        implementation("org.bouncycastle:bcpkix-jdk18on:1.82") {
+            because("Older versions have security vulnerabilities")
+        }
+    }
+
     implementation(mn.micronaut.aop)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@
 # a managed version (a version which alias starts with "managed-"
 
 [versions]
-micronaut = "4.9.4"
+micronaut = "4.9.12"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.7.0"
 groovy = "4.0.22"


### PR DESCRIPTION
[CVE-2025-8916](https://ossindex.sonatype.org/vulnerability/CVE-2025-8916?component-type=maven&component-name=org.bouncycastle%2Fbcpkix-jdk18on&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.2)