### PR TITLE
Update graalpy to 25.0.2

### DIFF
--- a/graalpy/src/main/java/io/micronaut/graal/graalpy/DefaultGraalPyContextBuilderFactory.java
+++ b/graalpy/src/main/java/io/micronaut/graal/graalpy/DefaultGraalPyContextBuilderFactory.java
@@ -18,7 +18,7 @@ package io.micronaut.graal.graalpy;
 import io.micronaut.core.annotation.Experimental;
 import jakarta.inject.Singleton;
 import org.graalvm.polyglot.Context;
-import org.graalvm.python.embedding.utils.GraalPyResources;
+import org.graalvm.python.embedding.GraalPyResources;
 
 @Experimental
 @Singleton

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ micronaut = "4.10.3"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.9.0"
 groovy = "4.0.22"
-managed-graalpy = "24.2.2"
+managed-graalpy = "25.0.2"
 
 [libraries]
 # Core

--- a/test-suite-graalpy/src/test/java/io/micronaut/graal/graalpy/TestContextFactory.java
+++ b/test-suite-graalpy/src/test/java/io/micronaut/graal/graalpy/TestContextFactory.java
@@ -5,7 +5,7 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import jakarta.inject.Singleton;
 import org.graalvm.polyglot.Context;
-import org.graalvm.python.embedding.utils.GraalPyResources;
+import org.graalvm.python.embedding.GraalPyResources;
 
 @Bean
 @Singleton


### PR DESCRIPTION
Closes: #129 
by upgrading to graalpy 25.0.2 native image build pass 
<img width="1011" height="579" alt="image" src="https://github.com/user-attachments/assets/46eec6f6-a032-4a31-b465-24ddd090ca9b" />
but i had to override `org.graalvm.python:python-embedding` to 25.0.2 because it was pulled from platform as a transative with version 24.2.2. https://github.com/micronaut-projects/micronaut-platform/blob/35c1f7a18bb55032ac46072d68090502290d98dd/gradle/libs.versions.toml#L90

