### PR TITLE
Add Serde regression coverage for GraalPy sample

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,12 +17,15 @@
 
 [versions]
 micronaut = "5.0.0"
+micronaut-serde = "3.0.0-RC3"
 managed-graalpy = "25.0.3"
 managed-graalpy-embedding = "25.0.3"
 
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
+micronaut-serde-jackson = { module = 'io.micronaut.serde:micronaut-serde-jackson', version.ref = 'micronaut-serde' }
+micronaut-serde-processor = { module = 'io.micronaut.serde:micronaut-serde-processor', version.ref = 'micronaut-serde' }
 
 managed-graalpy = { module = 'org.graalvm.python:python', version.ref = 'managed-graalpy' }
 managed-graalpy-embedding = { module = 'org.graalvm.python:python-embedding', version.ref = 'managed-graalpy-embedding' }

--- a/test-suite-graalpy/build.gradle
+++ b/test-suite-graalpy/build.gradle
@@ -6,6 +6,8 @@ plugins {
 dependencies {
     testImplementation(projects.micronautGraalpy)
     testAnnotationProcessor(mn.micronaut.inject.java)
+    testAnnotationProcessor(libs.micronaut.serde.processor)
+    testImplementation(libs.micronaut.serde.jackson)
     testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(mnTest.junit.jupiter.engine)
     testRuntimeOnly(mnTest.junit.platform.launcher)

--- a/test-suite-graalpy/src/test/java/io/micronaut/graal/graalpy/ExampleTest.java
+++ b/test-suite-graalpy/src/test/java/io/micronaut/graal/graalpy/ExampleTest.java
@@ -1,6 +1,7 @@
 package io.micronaut.graal.graalpy;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.json.JsonMapper;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Inject;
 import org.graalvm.polyglot.Value;
@@ -8,6 +9,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.beans.beancontext.BeanContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -21,6 +24,7 @@ public class ExampleTest {
 
     @Inject ApplicationContext beanContext;
     @Inject GraalPyContext pyContext;
+    @Inject JsonMapper jsonMapper;
 
     @Test
     void testDealerService() {
@@ -45,5 +49,27 @@ public class ExampleTest {
         DocExample service = beanContext.getBean(DocExample.class);
         Object[] cards = service.play();
         assertEquals(Set.of(cards), Set.of(1, 2, 3));
+    }
+
+    @Test
+    void testDeserializeNestedSerdeableRecord() throws IOException {
+        byte[] json = """
+            {
+              "fileName": "review.txt",
+              "sentiment": {
+                "positive": 0.75,
+                "neutral": 0.2,
+                "negative": 0.05,
+                "compound": 0.91,
+                "label": "positive"
+              }
+            }
+            """.getBytes(StandardCharsets.UTF_8);
+
+        SentimentAnalysis analysis = jsonMapper.readValue(json, SentimentAnalysis.class);
+
+        assertEquals("review.txt", analysis.fileName());
+        assertEquals("positive", analysis.sentiment().label());
+        assertEquals(0.91, analysis.sentiment().compound());
     }
 }

--- a/test-suite-graalpy/src/test/java/io/micronaut/graal/graalpy/SentimentAnalysis.java
+++ b/test-suite-graalpy/src/test/java/io/micronaut/graal/graalpy/SentimentAnalysis.java
@@ -1,0 +1,16 @@
+package io.micronaut.graal.graalpy;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record SentimentAnalysis(String fileName, SentimentScores sentiment) {
+    @Serdeable
+    public record SentimentScores(
+            double positive,
+            double neutral,
+            double negative,
+            double compound,
+            String label
+    ) {
+    }
+}


### PR DESCRIPTION
## Summary
- Add Micronaut Serde runtime and processor dependencies to the GraalPy test suite.
- Add a regression record that matches the nested `@Serdeable` shape from issue #147.
- Verify nested Serdeable record deserialization through `JsonMapper` with the current Micronaut 5 / Serde combination.

## Testing
- `./gradlew :test-suite-graalpy:test --stacktrace`
- `./gradlew test`

Closes #147
